### PR TITLE
Fixes cgo type mismatch

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -190,7 +190,7 @@ func (this *Packet) Duration() int {
 }
 
 func (this *Packet) SetDuration(duration int) {
-	this.avPacket.duration = C.int(duration)
+	this.avPacket.duration = C.int64_t(duration)
 }
 
 func (this *Packet) StreamIndex() int {


### PR DESCRIPTION
Fixes the following error:

/root/gopath/src/github.com/3d0c/gmf/packet.go:193: cannot use C.int(duration) (type C.int) as type C.int64_t in assignment
