### PR TITLE
Fixes cgo type mismatch

### DIFF
--- a/codecCtx.go
+++ b/codecCtx.go
@@ -282,7 +282,7 @@ func (this *CodecCtx) Channels() int {
 }
 
 func (this *CodecCtx) SetBitRate(val int) *CodecCtx {
-	this.avCodecCtx.bit_rate = C.int(val)
+	this.avCodecCtx.bit_rate = C.int64_t(val)
 	return this
 }
 


### PR DESCRIPTION
Fixes the following error:

/root/gopath/src/github.com/3d0c/gmf/codecCtx.go:285: cannot use C.int(val) (type C.int) as type C.int64_t in assignment
